### PR TITLE
Add 'passthru' config field

### DIFF
--- a/examples/local-dep/nia/sirdi.json
+++ b/examples/local-dep/nia/sirdi.json
@@ -1,1 +1,14 @@
-{ "deps": [ { "local" : "../examp" } ], "modules": [ "Nia" ], "main": "Nia" }
+{
+  "deps": [
+    {
+      "local": "../examp"
+    }
+  ],
+  "modules": [
+    "Nia"
+  ],
+  "main": "Nia",
+  "passthru": {
+    "prebuild": "echo Hello from Nias build phase"
+  }
+}

--- a/examples/local-dep/nia/sirdi.json
+++ b/examples/local-dep/nia/sirdi.json
@@ -9,6 +9,6 @@
   ],
   "main": "Nia",
   "passthru": {
-    "prebuild": "echo Hello from Nias build phase"
+    "prebuild": "echo Hello from\necho Nia\\'s build phase"
   }
 }

--- a/src/Build.idr
+++ b/src/Build.idr
@@ -37,7 +37,14 @@ doBuild name = do
 
     traverse_ doBuildDep depNames
 
-    let ipkg = MkIpkg { name = name, depends = depNames, modules = config.modules, main = config.main, exec = "main" <$ config.main }
+    let ipkg = MkIpkg {
+        name = name,
+        depends = depNames,
+        modules = config.modules,
+        main = config.main,
+        exec = "main" <$ config.main,
+        passthru = config.passthru
+    }
 
     writeIpkg ipkg "\{dir}/\{name}.ipkg"
 

--- a/src/Config.idr
+++ b/src/Config.idr
@@ -3,7 +3,6 @@ module Config
 import System.File.ReadWrite
 import Language.JSON
 import Data.List
-import Data.Maybe
 import Util
 
 
@@ -36,11 +35,10 @@ parseConfig s = case parse s of
                      Just (JObject obj) => do
                         deps <- lookup "deps" obj >>= parseDeps
                         mods <- lookup "modules" obj >>= parseMods
+                        let main = lookup "main" obj >>= parseMain
 
-                        -- Surely there is a better way of writing this lol
-                        let main = parseMain <$> lookup "main" obj
-                        let pthru = fromMaybe [] (lookup "passthru" obj >>= parsePassthru)
-                        main <- sequence main
+                        let pthru = catMaybes . sequence $
+                            (lookup "passthru" obj >>= parsePassthru)
 
                         Just $ MkConfig deps mods main pthru
                      _ => Nothing

--- a/src/Ipkg.idr
+++ b/src/Ipkg.idr
@@ -1,6 +1,7 @@
 module Ipkg
 
 import Data.List
+import Data.String
 import System.File.ReadWrite
 import Util
 
@@ -13,12 +14,14 @@ record Ipkg where
     modules : List String
     main : Maybe String
     exec : Maybe String
+    passthru : List (String, String)
 
 
 Show Ipkg where
     show p = let depends = if p.depends == [] then "" else "depends = \{concat $ intersperse ", " p.depends}"
                  mains = case p.main of { Just s => "main = \{s}"; Nothing => "" }
                  exec = case p.exec of { Just s => "executable = \{s}"; Nothing => "" }
+                 passthru = unlines $ map (\(k, s) => "\{k} = \{show s}" ) p.passthru
       in """
 package \{p.name}
 sourcedir = "src"
@@ -26,6 +29,7 @@ modules = \{concat $ intersperse ", " p.modules}
 \{depends}
 \{mains}
 \{exec}
+\{passthru}
 """
 
 

--- a/src/Ipkg.idr
+++ b/src/Ipkg.idr
@@ -21,7 +21,7 @@ Show Ipkg where
     show p = let depends = if p.depends == [] then "" else "depends = \{concat $ intersperse ", " p.depends}"
                  mains = case p.main of { Just s => "main = \{s}"; Nothing => "" }
                  exec = case p.exec of { Just s => "executable = \{s}"; Nothing => "" }
-                 passthru = unlines $ map (\(k, s) => "\{k} = \{show s}" ) p.passthru
+                 passthru = fastUnlines $ map (\(k, s) => "\{k} = \"\{s}\"" ) p.passthru
       in """
 package \{p.name}
 sourcedir = "src"


### PR DESCRIPTION
Not necessarily the best way to do this, but it allows developers to forward arbitrary fields to the generated ipkg file.