### PR TITLE
Allow legacy packages

### DIFF
--- a/examples/local-dep/nia/sirdi.json
+++ b/examples/local-dep/nia/sirdi.json
@@ -5,6 +5,10 @@
     {
       "name": "examp",
       "local": "../examp"
+    },
+    {
+      "name": "contrib",
+      "legacy": true
     }
   ],
   "modules": [

--- a/examples/local-dep/nia/src/Nia.idr
+++ b/examples/local-dep/nia/src/Nia.idr
@@ -1,6 +1,7 @@
 module Nia
 
 import Examp
+import Language.JSON
 
 main : IO ()
 main = do

--- a/src/Build.idr
+++ b/src/Build.idr
@@ -17,6 +17,7 @@ fetchTo (Local source) dest = do
     ignore $ createDir "\{dest}"
     mSystem "cp \{source}/sirdi.json \{dest}/sirdi.json" "Failed to copy \{source}/sirdi.json"
     mSystem "cp -r \{source}/src \{dest}/src" "Failed to copy \{source}/src"
+fetchTo Legacy _ = pure ()
 
 
 createBuildDirs : M ()
@@ -33,7 +34,7 @@ installDep name = do
 
 
 buildDependency : Dependency -> M ()
-buildDependency dep = do
+buildDependency dep = unless (isLegacy dep) $ do
     putStrLn "Building \{dep.name}"
 
     let dir = ".build/sources/\{depID dep}"
@@ -66,7 +67,7 @@ buildDependency dep = do
 
 -- TODO: perhaps rename "Dependency" to "Package"
 fetchDependency : Dependency -> M ()
-fetchDependency dep = do
+fetchDependency dep = unless (isLegacy dep) $ do
     -- Calculate where the dependency should be fetched to.
     let dir = ".build/sources/\{depID dep}"
 

--- a/src/Build.idr
+++ b/src/Build.idr
@@ -84,15 +84,17 @@ fetchDependency dep = unless (isLegacy dep) $ do
 
 
 makeDepTree : Dependency -> M DepTree
-makeDepTree dep = do
-    let dir = ".build/sources/\{depID dep}"
+makeDepTree dep = case isLegacy dep of
+    True => pure $ Node dep []
+    False => do
+        let dir = ".build/sources/\{depID dep}"
 
-    multiConfig <- readConfig dir
-    config <- findSubConfig dep.name multiConfig
+        multiConfig <- readConfig dir
+        config <- findSubConfig dep.name multiConfig
 
-    children <- traverse makeDepTree config.deps
+        children <- traverse makeDepTree config.deps
 
-    pure $ Node dep children
+        pure $ Node dep children
 
 
 export

--- a/src/Config.idr
+++ b/src/Config.idr
@@ -100,7 +100,7 @@ pConfig s = case parse s of
 
             parseDeps : JSON -> P (List Dependency)
             parseDeps (JArray deps) = sequence (map parseDep deps)
-            parseDeps x = Left "Expected a list of depdencies, instead got \{show x}"
+            parseDeps x = Left "Expected a list of dependencies, instead got \{show x}"
 
             parseMods : JSON -> P (List String)
             parseMods (JArray mods) = sequence (map getStr mods)

--- a/src/Config.idr
+++ b/src/Config.idr
@@ -133,7 +133,7 @@ readConfig : (dir : String) -> M MultiConfig
 readConfig dir = do
     let filepath = "\{dir}/sirdi.json"
 
-    Right contents <- mIO (readFile filepath) | Left err => mErr "Can't find file \{filepath}"
+    Right contents <- readFile filepath | Left err => mErr "Can't find file \{filepath}"
 
     case pConfig contents of
          Right config => pure config

--- a/src/Config.idr
+++ b/src/Config.idr
@@ -17,6 +17,7 @@ public export
 data Source
     = Git URL
     | Local FilePath
+    | Legacy
 
 
 public export
@@ -25,10 +26,15 @@ record Dependency where
     name : String
     source : Source
 
+export
+isLegacy : Dependency -> Bool
+isLegacy (MkDep _ Legacy) = True
+isLegacy _ = False
 
 hashSource : Source -> String
 hashSource (Git url) = show $ hash url
 hashSource (Local fp) = show $ hash fp
+hashSource Legacy = ""
 
 
 export
@@ -80,7 +86,10 @@ pConfig s = case parse s of
             parseSource : (String, JSON) -> P Source
             parseSource ("git", x) = Git <$> getStr x
             parseSource ("local", x) = Local <$> getStr x
-            parseSource x = Left "Expected { 'git': ... } or  { 'local': ... }, instead got \{show x}"
+            parseSource ("legacy", x) = pure Legacy
+            parseSource x = Left
+                $ "Expected one of { 'git': ... }, { 'local': ... }, or { 'legacy': ... }\n"
+                ++ "instead got \{show x}"
 
             parseDep : JSON -> P Dependency
             parseDep (JObject [("name", name), source]) = MkDep <$> getStr name <*> parseSource source

--- a/src/DepTree.idr
+++ b/src/DepTree.idr
@@ -30,6 +30,6 @@ showTree indent node =
         "\{indent} +- \{showDep node.val}\n\{subtrees}"
 
 
-public export
+public export covering
 Show DepTree where
   show = showTree ""

--- a/src/DepTree.idr
+++ b/src/DepTree.idr
@@ -27,7 +27,7 @@ showDep dep = "\{dep.name} (\{showSrc dep.source})"
 
 showTree : String -> DepTree -> String
 showTree indent node =
-    let subtrees = unlines $ map (showTree $ indent ++ " |  ") node.children in
+    let subtrees = fastConcat $ map (showTree $ indent ++ " |  ") node.children in
         "\{indent} +- \{showDep node.val}\n\{subtrees}"
 
 

--- a/src/DepTree.idr
+++ b/src/DepTree.idr
@@ -22,6 +22,7 @@ showDep dep = "\{dep.name} (\{showSrc dep.source})"
         showSrc : Source -> String
         showSrc (Git x)   = x
         showSrc (Local x) = x
+        showSrc Legacy = "legacy"
 
 
 showTree : String -> DepTree -> String

--- a/src/Ipkg.idr
+++ b/src/Ipkg.idr
@@ -36,5 +36,5 @@ modules = \{concat $ intersperse ", " p.modules}
 public export
 writeIpkg : Ipkg -> String -> M ()
 writeIpkg ipkg dest = do
-    Right () <- mIO $ writeFile dest (show ipkg) | Left err => mErr $ show err
+    Right () <- writeFile dest (show ipkg) | Left err => mErr $ show err
     pure ()

--- a/src/Util.idr
+++ b/src/Util.idr
@@ -31,8 +31,8 @@ Monad M where
 
 
 export
-mIO : IO a -> M a
-mIO = MkM . map Right
+HasIO M where
+    liftIO = MkM . map Right
 
 export
 mErr : String -> M a
@@ -51,7 +51,7 @@ runM m = do
 export
 mSystem : (command : String) -> (onErr : String) -> M ()
 mSystem command onErr = do
-    n <- mIO $ system command
+    n <- system command
     case n of
          0 => pure ()
          _ => mErr onErr


### PR DESCRIPTION
- Refactoring: `mIO` to `liftIO`, so `HasIO` functions can be used directly
- Allow "legacy" dependencies, or packages already installed on the system
- `Show` is total by default in `idris2/main`