### PR TITLE
Update package names to match valid idris ones

### DIFF
--- a/src/Package/Description/Parse.idr
+++ b/src/Package/Description/Parse.idr
@@ -32,9 +32,11 @@ pDescription s = case parse s of
             parseName : JSON -> P String
             parseName json = do
                 s <- getStr json
-                if length s > 0 && all isAlpha (unpack s)
-                   then pure s
-                   else Left "Invalid package name \{s}"
+                case unpack s of
+                    [] => Left "Expected package name, found empty string"
+                    h :: ts => if isAlpha h && all (\t => isAlphaNum t || t == '-') ts
+                        then pure s
+                        else Left "Invalid package name \{s}"
 
             parseGit : JSON -> P (URL, Maybe CommitHash)
             parseGit (JObject [("url", url), ("commit", ch)]) = pure (!(getStr url), Just !(getStr ch))


### PR DESCRIPTION
Idris2 supports numbers and hyphens in package names, only the first character needs to be a alpha character
See https://github.com/idris-lang/Idris2/blob/main/src/Parser/Lexer/Common.idr#L35

For a package to rely on the 'idris2' package﻿ for example, this must be supported
