### PR TITLE
Add executable field

### DIFF
--- a/src/Build.idr
+++ b/src/Build.idr
@@ -87,7 +87,7 @@ compile (Node (ident, config) deps) = case (isLegacy ident.source) of
                 depends = depNames,
                 modules = config.modules,
                 main = config.main,
-                exec = "main" <$ config.main,
+                exec = config.executable,
                 passthru = config.passthru
             }
 

--- a/src/Package/Description.idr
+++ b/src/Package/Description.idr
@@ -12,12 +12,13 @@ record Description where
     deps : List (Identifier MaybePinned)
     modules : List String -- Need a better type for module names maybe?
     main : Maybe String
+    executable : Maybe String
     passthru : List (String, String)
 
 
 export
 emptyDescription : Description
-emptyDescription = MkDescription [] [] Nothing []
+emptyDescription = MkDescription [] [] Nothing Nothing []
 
 
 public export

--- a/src/Package/Description/Parse.idr
+++ b/src/Package/Description/Parse.idr
@@ -84,11 +84,14 @@ pDescription s = case parse s of
                 -- JSON. Equally, if the key isn't present, then that should be fine too.
                 let main = parseMain <$> lookup "main" obj
                 main <- sequence main
+                exec <- case main of
+                        Nothing => pure Nothing
+                        Just _ => Just <$> (lookup' "executable" obj >>= getStr)
 
                 let pthru = catMaybes . sequence $
                     (lookup "passthru" obj >>= parsePassthru)
 
-                pure $ (pkgName, MkDescription deps mods main pthru)
+                pure $ (pkgName, MkDescription deps mods main exec pthru)
             parseDescription x = Left "Expected config object, instead got \{show x}"
 
             parseMultiDescription : JSON -> P MultiDescription


### PR DESCRIPTION
This is only checked if there is a main field, as executable doesn't make sense without main﻿
