### PR TITLE
Makefile tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build/
 depends
 failures
 output
+
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ INSTALL_DIR = ~/.idris2/bin
 
 .PHONY: build prebuild test testbin clean install
 
-build: prebuild
+build: ./depends/hashable-0
 	idris2 --build sirdi.ipkg
 
 prebuild:
@@ -15,10 +15,21 @@ test:
 	make -C tests test
 
 clean:
-	rm -r build/
-	rm -r depends
+	rm -rf ./build
+	rm -rf ./depends
 	make -C tests clean
 
-install: build
+install: ./build/exec/sirdi ./build/exec/sirdi_app
 	install build/exec/sirdi $(INSTALL_DIR)
-	install build/exec/sirdi_app/* $(INSTALL_DIR)/sirdi_app
+	mkdir -p $(INSTALL_DIR)/sirdi_app
+	install $(wildcard build/exec/sirdi_app/*) $(INSTALL_DIR)/sirdi_app/
+
+./depends/hashable-0:
+	make prebuild
+
+./build/exec/sirdi:
+	make build
+
+./build/exec/sirdi_app:
+	make build
+

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -13,5 +13,5 @@ main = runner
     [ testPaths "sirdi" allTests ]
     where
       testPaths : String -> TestPool -> TestPool
-      testPaths dir = record { testCases $= map ((dir ++ "/" ++)) }
+      testPaths dir = { testCases $= map ((dir ++ "/" ++)) }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,10 +7,10 @@ INTERACTIVE ?= --interactive
 
 .PHONY: testbin test
 
-test:
+test: ./build/exec/runtests
 	./build/exec/runtests $(SIRDI) $(INTERACTIVE) --failure-file failures --only $(only)
 
-retest:
+retest: ./build/exec/runtests
 	@touch failures
 	./build/exec/runtests $(SIRDI) $(INTERACTIVE) --failure-file failures --only-file failures --only $(only)
 
@@ -18,5 +18,7 @@ testbin:
 	idris2 --build tests.ipkg
 
 clean:
-	rm -r build
+	rm -rf ./build
 
+./build/exec/runtests:
+	make testbin


### PR DESCRIPTION
At least one Mac OS, the makefile was causing me a bit of frustration so I made some tweaks that are hopefully appropriate for other platforms as well.

- Fixes errors caused by `install` not both creating the `sirdi_app` directory and also expanding all glob patterns.
- Adds `-f` to `rm` calls in `make clean` targets because those were requiring me to say "yes" to each deletion and they also threw errors for directories that didn't exist (like if I had not built the tests prior to cleaning the main project).
- Avoids rebuilding depends when running make multiple times (unless you've cleaned), avoids rebuilding project when running make install (unless you've cleaned).
- Builds test binary before running tests upon `make test` unless the binary is already built.

I (somewhat randomly) also removed a `record` keyword (since it is deprecated and produces a warning with latest builds of Idris 2 HEAD).
