### PR TITLE
Add version to package descriptions and forward on to ipkg files.

### DIFF
--- a/src/Build.idr
+++ b/src/Build.idr
@@ -5,6 +5,7 @@ import System.Directory
 import System.File
 import Ipkg
 import Util
+import Version
 import DepTree
 import Data.List
 import Package.Description
@@ -84,6 +85,7 @@ compile (Node (ident, config) deps) = case (isLegacy ident.source) of
             let fname = "\{ident.sourceDir}/\{ident.name}.ipkg"
             let ipkg = MkIpkg {
                 name = ident.name,
+                version = config.version,
                 depends = depNames,
                 modules = config.modules,
                 main = config.main,

--- a/src/Package/Description.idr
+++ b/src/Package/Description.idr
@@ -3,12 +3,14 @@ module Package.Description
 import Package.Identifier
 import Package.Source
 import Util
+import Version
 import Data.List
 
 
 public export
 record Description where
     constructor MkDescription
+    version : Maybe Version
     deps : List (Identifier MaybePinned)
     modules : List String -- Need a better type for module names maybe?
     main : Maybe String
@@ -17,7 +19,7 @@ record Description where
 
 export
 emptyDescription : Description
-emptyDescription = MkDescription [] [] Nothing []
+emptyDescription = MkDescription Nothing [] [] Nothing []
 
 
 public export

--- a/src/Version.idr
+++ b/src/Version.idr
@@ -1,0 +1,121 @@
+||| Provides semantic versioning `Version` type and utilities.
+||| See [semver](https://semver.org/) for proper definition of semantic versioning
+|||
+||| Almost entirely borrowed from Idris compiler codebase.
+module Version
+
+import Data.List
+import Data.String
+
+import Text.Parser
+import Text.Lexer
+
+%default total
+
+||| Semantic versioning with optional tag
+public export
+record Version where
+  constructor MkVersion
+  ||| Semantic version
+  ||| Should follow the (major, minor, patch) convention
+  semVer : (Nat, Nat, Nat)
+  ||| Optional tag
+  ||| Usually contains git sha1 of this software's build in between releases
+  versionTag : Maybe String
+
+||| String representation of a Version with optional display of `tag`
+export
+showVersion : Bool -> Version -> String
+showVersion tag (MkVersion (maj,min,patch) versionTag) =
+  concat (intersperse "." (map show [ maj, min, patch])) ++
+         if tag then showTag else ""
+  where
+    showTag : String
+    showTag = case versionTag of
+                Nothing => ""
+                Just tag => "-" ++ tag
+
+export
+Show Version where
+  show = showVersion True
+
+export
+Eq Version where
+  (==) (MkVersion ver tag) (MkVersion ver' tag') = ver == ver' && tag == tag'
+
+export
+Ord Version where
+  compare (MkVersion ver tag) (MkVersion ver' tag')  =
+    case compare ver ver' of
+      EQ => compare tag tag'
+      other => other
+
+--------------------------------------------------------------------------------
+-- Parser
+--------------------------------------------------------------------------------
+
+data VersionTokenKind = VersionText | VersionNum | VersionDot | VersionDash
+
+Eq VersionTokenKind where
+  (==) VersionText VersionText = True
+  (==) VersionNum VersionNum = True
+  (==) VersionDot VersionDot = True
+  (==) VersionDash VersionDash = True
+  (==) _ _ = False
+
+
+VersionToken : Type
+VersionToken = Token VersionTokenKind
+
+TokenKind VersionTokenKind where
+  TokType VersionText = String
+  TokType VersionDot = ()
+  TokType VersionDash = ()
+  TokType VersionNum = Nat
+
+  tokValue VersionText x = x
+  tokValue VersionDot _ = ()
+  tokValue VersionDash _ = ()
+  tokValue VersionNum n = stringToNatOrZ n
+
+versionTokenMap : TokenMap VersionToken
+versionTokenMap = toTokenMap $
+  [ (is '.', VersionDot)
+  , (is '-', VersionDash)
+  , (digits, VersionNum)
+  , (some alphaNum, VersionText)
+  ]
+
+lexVersion : String -> List (WithBounds VersionToken)
+lexVersion str =
+  let
+    (tokens, _, _, _) = lex versionTokenMap str
+  in
+    tokens
+
+
+versionParser : Grammar () VersionToken True Version
+versionParser = do
+  maj <- match VersionNum
+  match VersionDot
+  min <- match VersionNum
+  match VersionDot
+  patch <- match VersionNum
+  optTag <- optional $ match VersionDash *> match VersionText
+  pure $ MkVersion (maj, min, patch) optTag
+
+||| Parse given string into a proper `Version` record
+|||
+||| Expected format must be:
+||| ```
+||| <major>.<minor>.<patch>(-<tag>)?
+||| ```
+||| where <major>, <minor> and <patch> are natural integers and tag is an optional
+||| alpha-numeric string.
+export
+parseVersion : String -> Maybe Version
+parseVersion str =
+  case parse versionParser (lexVersion str) of
+       Right (version, _) => Just version
+       _ => Nothing
+


### PR DESCRIPTION
Add an optional version field to the Sirdi manifest format.

This can be expanded upon to hook into dependency resolution in the future, but my motivation thus far is a bit more basic: support the fields I already put in `ipkg` files to begin with.

As a package maintainer, I want to support Sirdi but also hold onto my existing `ipkg` file so I can support users that prefer what Sirdi considers a "legacy" install. To do this, it would be ideal if running a sirdi build did not destroy information in my `ipkg` file.

All the fields I want to specify can be specified in `passthru` except for version, which is not a string value. Since I think that using versioning could become a robust strategy for Sirdi dependency resolution, adding the version field like this feels like a win-win for now.