### PR TITLE
Support pulling from git

### DIFF
--- a/examples/legacy/sirdi.toml
+++ b/examples/legacy/sirdi.toml
@@ -1,0 +1,6 @@
+# [[dependencies]]
+# type = "git"
+# path = "https://github.com/stefan-hoeck/idris2-elab-util"
+
+
+dependencies = [ { type = "git", url = "https://gitlab.com/avidela/recombine", commit = "sirdi", path = "." } ]

--- a/sources/sirdi_cli/src/Errors.idr
+++ b/sources/sirdi_cli/src/Errors.idr
@@ -12,8 +12,8 @@ Show InitError where
 
 
 public export
-Show ConfigError where
-    show (TOMLError x) = "TOML Error: \{show x}"
+Show TOMLError where
+    show (ParseError x) = "Parse Error: \{show x}"
     show (ValidateError x) = "Validation error: \{x}"
 
 
@@ -23,8 +23,9 @@ Show (FetchError ident) where
     show (BadGitCommit badCommit) = "Bad git commit \{badCommit}"
     show (BadGitPath badPath) = "Bad git path \{show badPath}"
     show (BadLocalPath badPath) = "Bad local path \{show badPath}"
-    show NoConfigFile = "No config file"
-    show (BadConfig x) = "Bad config \{show x}"
+    show (NoConfigFile path) = "Config file \{path} not found"
+    show (BadTOML x) = "Bad toml config \{show x}"
+    show (NoValidConfigFile x y) = "Could not parse TOML: \{show x}\nFallback to IPKG failed: \{show y}"
 
 
 public export

--- a/sources/sirdi_lib/sirdi_lib.ipkg
+++ b/sources/sirdi_lib/sirdi_lib.ipkg
@@ -2,6 +2,17 @@ package sirdi_lib
 
 depends = idris2, toml, contrib, hashable
 
-modules = Sirdi, Sirdi.Core, Sirdi.Core.Build, Sirdi.Core.Run, Sirdi.Core.Fetch, Sirdi.Core.Config, Sirdi.Core.Init, Sirdi.Core.New, Util.All, Util.IOEither, Util.Files
+modules = Sirdi
+       , Sirdi.Core
+       , Sirdi.Core.Build
+       , Sirdi.Core.Run
+       , Sirdi.Core.Fetch
+       , Sirdi.Core.Config
+       , Sirdi.Core.Init
+       , Sirdi.Core.New
+       , Util.All
+       , Util.IOEither
+       , Util.Files
+       , Util.Git
 
 sourcedir = "src"

--- a/sources/sirdi_lib/src/Sirdi/Core/Fetch.idr
+++ b/sources/sirdi_lib/src/Sirdi/Core/Fetch.idr
@@ -1,3 +1,4 @@
+
 module Sirdi.Core.Fetch
 
 import Sirdi.Core
@@ -8,7 +9,19 @@ import Language.TOML
 import Data.Hashable
 import System.Path
 import System
+import System.Directory
+import System.Directory.Tree
 import System.File.ReadWrite
+import Util.Files
+import Util.Git
+import Idris.Package
+import Compiler.Common
+import Core.Core
+import Core.Context.Context
+import Core.Context
+import Idris.Syntax
+import Idris.REPL.Opts
+import Idris.Package.Types
 
 
 public export
@@ -19,9 +32,43 @@ data FetchError : Identifier -> Type where
 
     BadLocalPath : (badPath : Path) -> FetchError (Local badPath)
 
-    NoConfigFile : FetchError ident
-    BadConfig : ConfigError -> FetchError ident
 
+    NoConfigFile : String -> FetchError ident
+
+    -- TOML file could not be parsed or has the wrong format
+    BadTOML : TOMLError -> FetchError ident
+
+    -- Neither TOML nor IPKG could be parsed correctly
+    NoValidConfigFile : TOMLError -> Core.Error -> FetchError ident
+
+readConfigFile : String -> IOEither (FetchError ident) String
+readConfigFile filename =
+    case !(readFile filename) of
+        Left FileNotFound => throw (NoConfigFile filename)
+        Left e => putStrLn "Error while reading config file" >> die e
+        Right x => pure x
+
+||| Convert a ipkg to a description, because we do not know where to find them
+||| In principle the ipkg can have dependencies that are installed with the compiler
+||| such as network and linear but others won't be installed by Sirdi
+pkgToDesc : PkgDesc -> Description
+pkgToDesc pkg = MkDescription (snd <$> mainmod pkg) []
+
+parseipkg : String -> IOEither Core.Error Description
+parseipkg path = do
+
+    -- We need to Generate the global state in which `parsePkgFile` operates
+    defs <- coreToIOEither initDefs
+
+    r1 <- MkRef <$> newIORef defs
+    syn  <- MkRef <$> newIORef initSyntax
+    opts <- MkRef <$> newIORef (defaultOpts Nothing (REPL NoneLvl) [])
+
+    -- We parse the file for real
+    let p = parsePkgFile {c = r1} {s = syn} {o = opts} path
+    parsed <- coreToIOEither p
+
+    pure (pkgToDesc parsed)
 
 export
 fetch : Initialised => (ident : Identifier) -> IOEither (FetchError ident) (Package Fetched ident)
@@ -32,18 +79,51 @@ fetch (Local path) = do
 
     let cfgFile = path /> configName
 
-    contents <- case !(readFile $ show cfgFile) of
-        Left FileNotFound => throw NoConfigFile
-        Left e => putStrLn "Error while reading config file" >> die e
-        Right x => pure x
+    contents <- readConfigFile (show cfgFile)
 
     ignore $ system "cp -r \{show path}/src \{show destDir}/"
 
-    desc <- MkEitherT $ pure $ bimap BadConfig id $ parseDesc contents
+    desc <- MkEitherT $ pure $ bimap BadTOML id $ parseDesc contents
 
     pure $ MkPackage { desc = desc, identHash = identHash }
 
-fetch (Git url commit path) = do
-    putStrLn "GIT UNIMPLEMENTED!"
 
-    ?doFetch_rhs_1
+fetch (Git url commit path) = do
+    let identHash = show $ hash "git-\{commit}"
+    Just current <- map parse <$> currentDir
+      | Nothing => die "could not get current dir"
+    putStrLn "currentDir : \{current}"
+    -- clone to a temporary repo
+    removeDir "/tmp/sirdi"
+    unless !(exists "/tmp/sirdi")
+           (dieOnLeft $ createDir "/tmp/sirdi")
+    ignore $ changeDir "/tmp/sirdi"
+
+    Git.clone url (Just identHash)
+    ignore $ changeDir "/tmp/sirdi/\{identHash}"
+    Git.checkout commit
+
+    -- copy the temp directory into the current director
+    ignore $ changeDir (show current)
+    ignore $ copyDir (parse "/tmp/sirdi/\{identHash}") (parse ".sirdi/sources")
+    ignore $ removeDir "/tmp/sirdi/\{identHash}"
+
+    -- making the package by creating a hash and parsing the config file
+    -- if the config file cannot be parsed as a TOML file, the file is
+    -- parsed as a ipkg file, note that ipkg files cannot have dependencies themselves
+
+    ignore $ changeDir $ show (current /> identHash)
+    printLn (current /> identHash)
+    Just c <- currentDir
+      | Nothing => die "could not get current dir"
+    putStrLn "currentDir : \{c}"
+    contents <- readConfigFile $ show (current /> (identHash </> path))
+    ignore $ changeDir ".."
+
+    -- Attempt to parse as TOML first, if that fails, attempt to parse as IPKG, if both
+    -- fail, collect both errors in `NoValidConfigFile` so that we can report them
+    desc <- either (\err => mapErr (NoValidConfigFile err) (parseipkg contents))
+                   (MkEitherT . pure . Right)
+                   (parseDesc contents)
+
+    pure $ MkPackage { desc = desc, identHash = identHash }

--- a/sources/sirdi_lib/src/Sirdi/Core/New.idr
+++ b/sources/sirdi_lib/src/Sirdi/Core/New.idr
@@ -8,18 +8,18 @@ import Util.IOEither
 
 defaultDesc : String
 defaultDesc = """
-main = "Main"
-dependencies = []
-"""
+    main = "Main"
+    dependencies = []
+    """
 
 
 defaultMain : String
 defaultMain = """
-module Main
+    module Main
 
-main : IO ()
-main = putStrLn "Hello, world!"
-"""
+    main : IO ()
+    main = putStrLn "Hello, world!"
+    """
 
 
 public export

--- a/sources/sirdi_lib/src/Util/Files.idr
+++ b/sources/sirdi_lib/src/Util/Files.idr
@@ -2,7 +2,7 @@ module Util.Files
 
 import System.File.Process
 import System.File.ReadWrite
-
+import System
 
 readLinesOnto : HasIO io => (acc : List String) ->
                             (offset : Nat) ->
@@ -28,3 +28,4 @@ run cmd = do
         | Left err => pure Nothing
 
     pure (Just $ fastConcat lines)
+

--- a/sources/sirdi_lib/src/Util/Git.idr
+++ b/sources/sirdi_lib/src/Util/Git.idr
@@ -1,0 +1,12 @@
+module Util.Git
+
+import System
+import Data.Maybe
+
+export
+clone : HasIO io => String -> Maybe String -> io ()
+clone repo target = ignore $ system "git clone \{repo} \{fromMaybe "" target}"
+
+export
+checkout : HasIO io => String -> io ()
+checkout hashLike = ignore $ system "git checkout \{hashLike}"

--- a/sources/sirdi_lib/src/Util/IOEither.idr
+++ b/sources/sirdi_lib/src/Util/IOEither.idr
@@ -26,6 +26,11 @@ embed = MkEitherT
 
 
 export
+fromEither : Either a b -> IOEither a b
+fromEither = MkEitherT . pure
+
+
+export
 die : HasIO io => Show e => e -> io a
 die x = do
     putStrLn "Dying with unexpected error:"


### PR DESCRIPTION
This adds experimental support to pull repositories from git and was intended to lay the ground for pulling repositories which don't have a `sirdi.toml` file.

I think the way to go is to add an additional field `ipkg` that tells where the ipkg is relative to the `path`. This way we can know which `ipkg` to install, since it's quite common to have multiple of them in the same project.

I've added the functions to parse the ipkg but I've not implemented them since I didn't add the `ipkg` field in toml validation.

I would like to do it but my RSI is quite bad lately so this is all I can do