### PR TITLE
Only set PREFIX if not already set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX = ~/.idris2
+PREFIX ?= ~/.idris2
 INSTALL_DIR = $(PREFIX)/bin
 
 .PHONY: build prebuild test testbin clean install


### PR DESCRIPTION
Currently, the `PREFIX` in the makefile overwrites exported environment variables. By using `?=` instead of `=`, this behaviour is avoided and exported `PREFIX`es work as expected.